### PR TITLE
Added a parameter for tool types for them be dropped when the Pikmin …

### DIFF
--- a/Source/source/mob_fsms/pikmin_fsm.h
+++ b/Source/source/mob_fsms/pikmin_fsm.h
@@ -32,6 +32,7 @@ void begin_pluck(              mob* m, void* info1, void* info2);
 void sprout_evolve(            mob* m, void* info1, void* info2);
 void sprout_schedule_evol(     mob* m, void* info1, void* info2);
 void called(                   mob* m, void* info1, void* info2);
+void called_while_holding(      mob* m, void* info1, void* info2);
 void check_disabled_edible(    mob* m, void* info1, void* info2);
 void check_remove_flailing(    mob* m, void* info1, void* info2);
 void clear_timer(              mob* m, void* info1, void* info2);

--- a/Source/source/mob_types/tool_type.cpp
+++ b/Source/source/mob_types/tool_type.cpp
@@ -21,6 +21,7 @@ tool_type::tool_type() :
     mob_type(MOB_CATEGORY_TOOLS),
     bmp_icon(NULL),
     can_be_hotswapped(true),
+    dropped_when_pikmin_is_whistled(false),
     dropped_when_pikmin_lands(true),
     dropped_when_pikmin_lands_on_opponent(false),
     stuck_when_pikmin_lands_on_opponent(false),
@@ -35,6 +36,10 @@ tool_type::~tool_type() { }
  * Loads parameters from a data file.
  */
 void tool_type::load_parameters(data_node* file) {
+    dropped_when_pikmin_is_whistled =
+        s2b(
+            file->get_child_by_name("dropped_when_pikmin_is_whistled")->value
+        );
     dropped_when_pikmin_lands =
         s2b(
             file->get_child_by_name("dropped_when_pikmin_lands")->value

--- a/Source/source/mob_types/tool_type.h
+++ b/Source/source/mob_types/tool_type.h
@@ -22,6 +22,7 @@ public:
 
     ALLEGRO_BITMAP* bmp_icon;
     bool can_be_hotswapped;
+    bool dropped_when_pikmin_is_whistled;
     bool dropped_when_pikmin_lands;
     bool dropped_when_pikmin_lands_on_opponent;
     bool stuck_when_pikmin_lands_on_opponent;

--- a/Source/source/mobs/pikmin.cpp
+++ b/Source/source/mobs/pikmin.cpp
@@ -33,7 +33,9 @@ pikmin::pikmin(const point &pos, pikmin_type* type, const float angle) :
     missed_attack_ptr(nullptr),
     maturity(2),
     is_seed_or_sprout(false),
-    pluck_reserved(false) {
+    pluck_reserved(false),
+    latched(false),
+    is_tool_primed_for_whistle(false) {
     
     invuln_period = timer(PIKMIN_INVULN_PERIOD);
     team = MOB_TEAM_PLAYER_1; // TODO

--- a/Source/source/mobs/pikmin.h
+++ b/Source/source/mobs/pikmin.h
@@ -106,6 +106,8 @@ public:
     bool pluck_reserved;
     //Is this Pikmin latched on to a mob?
     bool latched;
+    //Is the Pikmin holding a tool and ready to drop it on whistle?
+    bool is_tool_primed_for_whistle;
     
     void force_carry(mob* m);
     bool process_attack_miss(hitbox_interaction* info);


### PR DESCRIPTION
…is whistled.

- In order for the whistled Pikmin to drop the tool only after it has been thrown, I've added a boolean that keeps track of whether the Pikmin has landed from a throw with the tool or not.